### PR TITLE
Update GH Action to use Node 24 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: 'npm'
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -38,10 +38,10 @@ jobs:
           sudo apt update
           sudo apt install -y gh
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/upgrade-actions-version.yml
+++ b/.github/workflows/upgrade-actions-version.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -314,5 +314,5 @@ outputs:
   status:
     description: 'The numeric exit code returned by the Black Duck Security Scan.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "devDependencies": {
         "@types/dom-parser": "0.1.4",
         "@types/jest": "29.5.12",
-        "@types/node": "20.19.37",
+        "@types/node": "^24.12.0",
         "@types/semver": "7.5.8",
         "@types/uuid": "9.0.8",
         "@typescript-eslint/eslint-plugin": "8.56.0",
@@ -39,8 +39,8 @@
         "eslint-plugin-prettier": "5.5.5",
         "jest": "30.3.0",
         "prettier": "3.3.3",
-        "ts-jest": "29.4.9",
-        "typescript": "4.9.5"
+        "ts-jest": "29.4.6",
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@actions/artifact": {
@@ -3001,12 +3001,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/semver": {
@@ -12304,16 +12304,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {
@@ -12674,9 +12674,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/dom-parser": "0.1.4",
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.37",
+    "@types/node": "^24.12.0",
     "@types/semver": "7.5.8",
     "@types/uuid": "9.0.8",
     "@typescript-eslint/eslint-plugin": "8.56.0",
@@ -41,8 +41,8 @@
     "eslint-plugin-prettier": "5.5.5",
     "jest": "30.3.0",
     "prettier": "3.3.3",
-    "ts-jest": "29.4.9",
-    "typescript": "4.9.5"
+    "ts-jest": "29.4.6",
+    "typescript": "^5.6.3"
   },
   "dependencies": {
     "@actions/artifact": "6.2.1",

--- a/src/blackduck-security-action/tool-cache-local.ts
+++ b/src/blackduck-security-action/tool-cache-local.ts
@@ -160,8 +160,10 @@ async function downloadWithCustomSSL(downloadUrl: string, dest: string, sslConfi
     const requestOptions = createHTTPSRequestOptions(parsedUrl, sslConfig, headerRecord)
 
     if (auth) {
-      if (requestOptions.headers) {
-        ;(requestOptions.headers as Record<string, string>).authorization = auth
+      const normalizedHeaders = Array.isArray(requestOptions.headers) ? {} : { ...(requestOptions.headers ?? {}) }
+      requestOptions.headers = {
+        ...normalizedHeaders,
+        authorization: auth
       }
     }
 

--- a/src/blackduck-security-action/tool-cache-local.ts
+++ b/src/blackduck-security-action/tool-cache-local.ts
@@ -258,6 +258,8 @@ async function downloadWithCustomSSL(downloadUrl: string, dest: string, sslConfi
 }
 
 function _getGlobal<T>(key: string, defaultValue: T): T {
+   
   const value = (global as any)[key] as T | undefined
+   
   return value !== undefined ? value : defaultValue
 }

--- a/test/unit/blackduck-security-action/utility.test.ts
+++ b/test/unit/blackduck-security-action/utility.test.ts
@@ -1,5 +1,7 @@
 import {checkJobResult, cleanUrl, isBoolean, isPullRequestEvent, createSSLConfiguredHttpClient, clearHttpClientCache, updateCoverityConfigForBridgeVersion, isVersionLess, isVersionGreaterOrEqual} from '../../../src/blackduck-security-action/utility'
 import * as constants from '../../../src/application-constants'
+import * as os from 'os'
+import * as path from 'path'
 test('cleanUrl() trailing slash', () => {
   const validUrl = 'https://my-domain.com'
   const testUrl = `${validUrl}/`
@@ -171,7 +173,7 @@ describe('SSL HTTP Client Functions', () => {
 
   describe('updateCoverityConfigForBridgeVersion', () => {
     test('should convert new format to legacy for Bridge CLI < 3.9.0', () => {
-      const tempFile = '/tmp/test_coverity_input.json'
+      const tempFile = path.join(os.tmpdir(), `test_coverity_input_${Date.now()}.json`)
       const testData = {
         data: {
           coverity: {
@@ -201,7 +203,7 @@ describe('SSL HTTP Client Functions', () => {
     })
 
     test('should preserve new format for Bridge CLI >= 3.9.0', () => {
-      const tempFile = '/tmp/test_coverity_input2.json'
+      const tempFile = path.join(os.tmpdir(), `test_coverity_input2_${Date.now()}.json`)
       const testData = {
         data: {
           coverity: {


### PR DESCRIPTION
This pull request resolves https://github.com/blackduck-inc/black-duck-security-scan/issues/165, a new requirement from GitHub that all runners must use node24 runners.

## Changes

In this PR, I have done the following

1. Update Runner Version to 24
2. Fix associated items
  - The @types/node was still pinned to node16, a small oversight from the last GHI Action runner update. this was updated to `"@types/node": "^24.12.0"`
  - Typescript also needed to be bumped from v4 to v5 to satisfy the new requirements. This was updated to `"^5.6.3"`

## Tests

All tests passed the first time, except for a couple which hard hard-coded Linux/macOS temp folder paths.  I fixed those paths to use best practice `os.tmpdir()`, instead of hard coded `/tmp/`, and now all tests pass.

<img width="340" height="94" alt="image" src="https://github.com/user-attachments/assets/22b5bde6-5d95-416d-a3a8-99c09b7501a8" />

------------------------------------------------------------------------------

Edits
1. Updated this post after fixing the tests and pushing a new commit to the PR
